### PR TITLE
feat(leon): harden fallback misconfiguration path and contract coverage (Fixes #303)

### DIFF
--- a/src/assistant/orchestrator.py
+++ b/src/assistant/orchestrator.py
@@ -65,6 +65,7 @@ def handle_message(
         "message": message,
         "detected_intent": intent,
         "use_leon_fallback": use_leon_fallback,
+        "leon_attempted": False,
     }
 
     if intent != "unknown":
@@ -98,6 +99,7 @@ def handle_message(
     if not LEON_CIRCUIT_BREAKER.allow_request():
         trace["route"] = "fallback-error"
         trace["reason"] = "circuit_open"
+        trace["leon_attempted"] = False
         LOGGER.warning("event=routing_decision cid=%s route=fallback-error intent=unknown reason=circuit_open", cid)
         return AssistantReply(
             intent=intent,
@@ -107,7 +109,30 @@ def handle_message(
             routing_trace=trace,
         )
 
-    leon = LeonClient.from_env()
+    try:
+        leon = LeonClient.from_env()
+    except RuntimeError as exc:
+        LEON_CIRCUIT_BREAKER.record_failure()
+        trace["route"] = "fallback-error"
+        trace["reason"] = "leon_misconfigured"
+        trace["leon_attempted"] = False
+        trace["leon_error"] = str(exc)
+        trace["consecutive_failures"] = LEON_CIRCUIT_BREAKER.consecutive_failures
+        LOGGER.warning(
+            "event=routing_decision cid=%s route=fallback-error intent=unknown "
+            "reason=leon_misconfigured failures=%s",
+            cid,
+            LEON_CIRCUIT_BREAKER.consecutive_failures,
+        )
+        return AssistantReply(
+            intent=intent,
+            answer="Service distant indisponible ou mal configure. Je reste en mode local degrade.",
+            source="fallback-error",
+            correlation_id=cid,
+            routing_trace=trace,
+        )
+
+    trace["leon_attempted"] = True
     leon_answer = leon.ask(message)
     if leon_answer:
         LEON_CIRCUIT_BREAKER.record_success()

--- a/tests/test_leon_client.py
+++ b/tests/test_leon_client.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import unittest
 from typing import Any
+from http.client import RemoteDisconnected
 from urllib import error
 from unittest.mock import patch
 
@@ -40,6 +41,23 @@ class TestLeonClient(unittest.TestCase):
         with patch("src.assistant.leon_client.request.urlopen", return_value=_FakeResponse(payload)):
             self.assertEqual(client.ask("salut"), "premiere reponse")
 
+    def test_ask_supports_messages_text_format(self) -> None:
+        client = LeonClient(base_url="http://localhost:1337")
+        payload = '{"messages":[{"text":"Bonjour depuis messages"}]}'
+        with patch("src.assistant.leon_client.request.urlopen", return_value=_FakeResponse(payload)):
+            self.assertEqual(client.ask("salut"), "Bonjour depuis messages")
+
+    def test_ask_supports_direct_output_field(self) -> None:
+        client = LeonClient(base_url="http://localhost:1337")
+        payload = '{"output":"Sortie Leon"}'
+        with patch("src.assistant.leon_client.request.urlopen", return_value=_FakeResponse(payload)):
+            self.assertEqual(client.ask("salut"), "Sortie Leon")
+
+    def test_ask_supports_raw_text_response(self) -> None:
+        client = LeonClient(base_url="http://localhost:1337")
+        with patch("src.assistant.leon_client.request.urlopen", return_value=_FakeResponse("Reponse brute Leon")):
+            self.assertEqual(client.ask("salut"), "Reponse brute Leon")
+
     def test_ask_returns_none_on_unexpected_json_format(self) -> None:
         client = LeonClient(base_url="http://localhost:1337")
         with patch("src.assistant.leon_client.request.urlopen", return_value=_FakeResponse('{"foo":42}')):
@@ -60,6 +78,15 @@ class TestLeonClient(unittest.TestCase):
             side_effect=[error.URLError("temporary"), _FakeResponse('{"answer":"OK apres retry"}')],
         ) as mocked:
             self.assertEqual(client.ask("salut"), "OK apres retry")
+            self.assertEqual(mocked.call_count, 2)
+
+    def test_ask_retries_on_remote_disconnect(self) -> None:
+        client = LeonClient(base_url="http://localhost:1337", retry_attempts=1)
+        with patch(
+            "src.assistant.leon_client.request.urlopen",
+            side_effect=[RemoteDisconnected("closed"), _FakeResponse('{"answer":"OK"}')],
+        ) as mocked:
+            self.assertEqual(client.ask("salut"), "OK")
             self.assertEqual(mocked.call_count, 2)
 
 

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -56,6 +56,7 @@ class TestOrchestrator(unittest.TestCase):
         self.assertEqual(reply.source, "leon")
         self.assertEqual(reply.answer, "Reponse Leon")
         self.assertEqual(reply.routing_trace.get("route"), "leon")
+        self.assertTrue(reply.routing_trace.get("leon_attempted"))
 
     @patch("src.assistant.orchestrator.LeonClient")
     def test_unknown_handles_unavailable_leon(self, mock_leon_cls: Any) -> None:
@@ -67,6 +68,19 @@ class TestOrchestrator(unittest.TestCase):
         self.assertEqual(reply.source, "fallback-error")
         self.assertIn("Leon", reply.answer)
         self.assertEqual(reply.routing_trace.get("route"), "fallback-error")
+        self.assertTrue(reply.routing_trace.get("leon_attempted"))
+
+    @patch("src.assistant.orchestrator.LeonClient")
+    def test_unknown_handles_misconfigured_leon_env(self, mock_leon_cls: Any) -> None:
+        mock_leon_cls.from_env.side_effect = RuntimeError("Variable d'environnement requise manquante: LEON_API_URL")
+
+        reply = handle_message("question inconnue", use_leon_fallback=True)
+
+        self.assertEqual(reply.source, "fallback-error")
+        self.assertIn("mode local degrade", reply.answer)
+        self.assertEqual(reply.routing_trace.get("reason"), "leon_misconfigured")
+        self.assertFalse(reply.routing_trace.get("leon_attempted"))
+        self.assertIn("LEON_API_URL", str(reply.routing_trace.get("leon_error")))
 
     def test_unknown_without_fallback_is_traceable(self) -> None:
         reply = handle_message("question inconnue", use_leon_fallback=False)


### PR DESCRIPTION
## Contexte
Ticket #303: hardening fallback Leon en mode production.

## Livraisons
- Gestion explicite de Leon mal configuré (sans crash)
  - src/assistant/orchestrator.py
- Enrichissement du trace de routage pour KPI fallback
  - src/assistant/orchestrator.py
- Extension des tests de contrat Leon
  - tests/test_leon_client.py
- Extension des tests orchestrateur (cas misconfiguration)
  - tests/test_orchestrator.py

## Détails techniques
- handle_message capture désormais RuntimeError de LeonClient.from_env()
- Retour utilisateur explicite en mode dégradé local au lieu d'exception non gérée
- Traçage enrichi: leon_attempted, leon_error, reason=leon_misconfigured

## Validation
- Tests ciblés: 20 passed
- Suite complète assistant: 405 passed

## Impact
- Robustesse accrue en prod lorsque variables LEON_* absentes/invalides
- Pas de crash orchestrateur sur intent inconnu + fallback actif

## Scope et traçabilité
Pour éviter un scope trop large dans un seul lot, les changements edge, firmware et documentation ont été livrés dans des PRs séparées:
- PR #310: stabilisation voix (capture, VAD, benchmark SLO)
- PR #312: firmware stream reconnect, backpressure, metrics
- PR #313: clarification multi-tour orchestrateur

Ce PR #311 couvre uniquement le hardening du fallback Leon et ses tests de contrat.