### PR TITLE
ci(pylint): align Python matrix with project baseline (3.10+)

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -6,8 +6,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -117,7 +117,7 @@ python3 scripts/sync_tickets.py --help
 → Assurez-vous d'être à la racine du repo: `cd VocalAssist`
 
 ### "python3: command not found"
-→ Installer Python 3.9+ (macOS: `brew install python3`, Ubuntu: `apt install python3`)
+→ Installer Python 3.10+ (macOS: `brew install python3`, Ubuntu: `apt install python3`)
 
 ## 📌 Bonnes pratiques
 


### PR DESCRIPTION
## Contexte\nLes PRs recentes etaient marquees UNSTABLE a cause du job Pylint en Python 3.8, alors que le projet cible Python 3.10+ (annotations modernes).\n\n## Changements\n- CI Pylint: matrice Python passe de 3.8/3.9/3.10 a 3.10/3.11/3.12\n- CI Pylint: ajout  pour voir tous les resultats de matrice\n- Documentation: prerequis Python dans GETTING_STARTED aligne a 3.10+\n\n## Impact\n- Suppression du bruit de faux positifs d analyse type sur 3.8\n- Checks CI plus coherents avec la baseline du projet\n\n## Fichiers\n- .github/workflows/pylint.yml\n- GETTING_STARTED.md\n