### PR TITLE
feat(observabilite): KPI continus, tracing correle, alertes panne (#307)

### DIFF
--- a/src/assistant/observability.py
+++ b/src/assistant/observability.py
@@ -1,0 +1,314 @@
+"""Observabilité produit: KPI, tracing corrélé, alertes.
+
+Module léger sans dépendance externe. Les métriques sont collectées
+en mémoire et peuvent être exportées (JSON/texte Prometheus-like).
+
+Usage:
+    from src.assistant.observability import MetricsCollector, AlertManager
+
+    collector = MetricsCollector()
+    collector.record_interaction(correlation_id="...", ...)
+    alerts = AlertManager(collector)
+    alerts.check_all()
+"""
+from __future__ import annotations
+
+import time
+from collections import defaultdict
+from dataclasses import dataclass, field
+from statistics import median
+from typing import Sequence
+
+
+# ---------------------------------------------------------------------------
+# Structures de données
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class InteractionTrace:
+    """Trace complète d'une interaction de bout en bout."""
+
+    correlation_id: str
+    intent: str
+    route: str  # "local" | "leon" | "clarification" | "error"
+    stt_ms: float = 0.0
+    orchestrator_ms: float = 0.0
+    tts_ms: float = 0.0
+    provider_name: str | None = None
+    provider_ms: float = 0.0
+    success: bool = True
+    error_type: str | None = None  # "provider_failure" | "leon_failure" | "timeout" | ...
+    timestamp: float = field(default_factory=time.time)
+
+    @property
+    def e2e_ms(self) -> float:
+        return self.stt_ms + self.orchestrator_ms + self.tts_ms + self.provider_ms
+
+
+@dataclass
+class KpiSummary:
+    """KPI agrégés sur un ensemble de traces."""
+
+    total_interactions: int
+    success_count: int
+    failure_count: int
+    success_rate: float  # 0.0–1.0
+    median_e2e_ms: float
+    p95_e2e_ms: float
+    intent_distribution: dict[str, int]
+    route_distribution: dict[str, int]
+    error_distribution: dict[str, int]
+
+    @property
+    def leon_failure_count(self) -> int:
+        return self.error_distribution.get("leon_failure", 0)
+
+    @property
+    def provider_failure_count(self) -> int:
+        return self.error_distribution.get("provider_failure", 0)
+
+
+# ---------------------------------------------------------------------------
+# Collecteur de métriques
+# ---------------------------------------------------------------------------
+
+
+class MetricsCollector:
+    """Collecte les traces d'interactions et calcule les KPI."""
+
+    def __init__(self) -> None:
+        self._traces: list[InteractionTrace] = []
+
+    # -- Enregistrement -------------------------------------------------------
+
+    def record(self, trace: InteractionTrace) -> None:
+        """Enregistre une trace d'interaction complète."""
+        self._traces.append(trace)
+
+    def record_interaction(
+        self,
+        *,
+        correlation_id: str,
+        intent: str,
+        route: str,
+        stt_ms: float = 0.0,
+        orchestrator_ms: float = 0.0,
+        tts_ms: float = 0.0,
+        provider_name: str | None = None,
+        provider_ms: float = 0.0,
+        success: bool = True,
+        error_type: str | None = None,
+    ) -> InteractionTrace:
+        trace = InteractionTrace(
+            correlation_id=correlation_id,
+            intent=intent,
+            route=route,
+            stt_ms=stt_ms,
+            orchestrator_ms=orchestrator_ms,
+            tts_ms=tts_ms,
+            provider_name=provider_name,
+            provider_ms=provider_ms,
+            success=success,
+            error_type=error_type,
+        )
+        self.record(trace)
+        return trace
+
+    # -- Accès aux données brutes ---------------------------------------------
+
+    def all_traces(self) -> list[InteractionTrace]:
+        return list(self._traces)
+
+    def traces_for_correlation(self, correlation_id: str) -> list[InteractionTrace]:
+        return [t for t in self._traces if t.correlation_id == correlation_id]
+
+    def unique_correlation_ids(self) -> set[str]:
+        return {t.correlation_id for t in self._traces}
+
+    def reset(self) -> None:
+        """Vide toutes les traces (utile pour les tests)."""
+        self._traces.clear()
+
+    # -- KPI ------------------------------------------------------------------
+
+    def kpi_summary(self, traces: Sequence[InteractionTrace] | None = None) -> KpiSummary:
+        """Calcule les KPI agrégés sur les traces fournies (ou toutes)."""
+        population = list(traces) if traces is not None else self._traces
+        if not population:
+            return KpiSummary(
+                total_interactions=0,
+                success_count=0,
+                failure_count=0,
+                success_rate=0.0,
+                median_e2e_ms=0.0,
+                p95_e2e_ms=0.0,
+                intent_distribution={},
+                route_distribution={},
+                error_distribution={},
+            )
+
+        success_count = sum(1 for t in population if t.success)
+        failure_count = len(population) - success_count
+
+        e2e_values = sorted(t.e2e_ms for t in population)
+        idx_95 = max(0, int((len(e2e_values) - 1) * 0.95))
+
+        intent_dist: dict[str, int] = defaultdict(int)
+        route_dist: dict[str, int] = defaultdict(int)
+        error_dist: dict[str, int] = defaultdict(int)
+
+        for t in population:
+            intent_dist[t.intent] += 1
+            route_dist[t.route] += 1
+            if t.error_type:
+                error_dist[t.error_type] += 1
+
+        return KpiSummary(
+            total_interactions=len(population),
+            success_count=success_count,
+            failure_count=failure_count,
+            success_rate=success_count / len(population),
+            median_e2e_ms=median(e2e_values),
+            p95_e2e_ms=e2e_values[idx_95],
+            intent_distribution=dict(intent_dist),
+            route_distribution=dict(route_dist),
+            error_distribution=dict(error_dist),
+        )
+
+    def kpi_for_parcours(self, intent: str) -> KpiSummary:
+        """KPI filtrés sur un parcours (intent) donné."""
+        traces = [t for t in self._traces if t.intent == intent]
+        return self.kpi_summary(traces)
+
+    # -- Export ---------------------------------------------------------------
+
+    def export_prometheus_text(self) -> str:
+        """Exporte les métriques dans un format texte Prometheus-compatible."""
+        kpi = self.kpi_summary()
+        lines: list[str] = [
+            "# HELP interactions_total Total d'interactions enregistrees",
+            "# TYPE interactions_total counter",
+            f"interactions_total {kpi.total_interactions}",
+            "# HELP interactions_success_total Interactions reussies",
+            "# TYPE interactions_success_total counter",
+            f"interactions_success_total {kpi.success_count}",
+            "# HELP interactions_failure_total Interactions en echec",
+            "# TYPE interactions_failure_total counter",
+            f"interactions_failure_total {kpi.failure_count}",
+            "# HELP success_rate Taux de succes (0-1)",
+            "# TYPE success_rate gauge",
+            f"success_rate {kpi.success_rate:.4f}",
+            "# HELP e2e_latency_ms_median Latence E2E mediane (ms)",
+            "# TYPE e2e_latency_ms_median gauge",
+            f"e2e_latency_ms_median {kpi.median_e2e_ms:.2f}",
+            "# HELP e2e_latency_ms_p95 Latence E2E p95 (ms)",
+            "# TYPE e2e_latency_ms_p95 gauge",
+            f"e2e_latency_ms_p95 {kpi.p95_e2e_ms:.2f}",
+        ]
+        for route, count in kpi.route_distribution.items():
+            lines.append(f'routing_total{{route="{route}"}} {count}')
+        for err, count in kpi.error_distribution.items():
+            lines.append(f'errors_total{{type="{err}"}} {count}')
+        return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Alertes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Alert:
+    level: str  # "warning" | "critical"
+    name: str
+    message: str
+    value: float
+    threshold: float
+
+
+class AlertManager:
+    """Vérifie les seuils critiques et lève des alertes."""
+
+    def __init__(
+        self,
+        collector: MetricsCollector,
+        *,
+        max_failure_rate: float = 0.20,           # 20%
+        max_p95_latency_ms: float = 2500.0,
+        max_leon_failure_rate: float = 0.10,      # 10%
+        max_provider_failure_rate: float = 0.10,  # 10%
+        min_interactions_for_alert: int = 3,
+    ) -> None:
+        self._collector = collector
+        self.max_failure_rate = max_failure_rate
+        self.max_p95_latency_ms = max_p95_latency_ms
+        self.max_leon_failure_rate = max_leon_failure_rate
+        self.max_provider_failure_rate = max_provider_failure_rate
+        self.min_interactions = min_interactions_for_alert
+
+    def check_all(self) -> list[Alert]:
+        """Retourne la liste de toutes les alertes actives."""
+        alerts: list[Alert] = []
+        kpi = self._collector.kpi_summary()
+
+        if kpi.total_interactions < self.min_interactions:
+            return alerts
+
+        # Taux d'échec global
+        failure_rate = 1.0 - kpi.success_rate
+        if failure_rate > self.max_failure_rate:
+            alerts.append(Alert(
+                level="critical",
+                name="high_failure_rate",
+                message=f"Taux d'echec {failure_rate:.1%} > seuil {self.max_failure_rate:.1%}",
+                value=failure_rate,
+                threshold=self.max_failure_rate,
+            ))
+
+        # Latence P95
+        if kpi.p95_e2e_ms > self.max_p95_latency_ms:
+            alerts.append(Alert(
+                level="warning",
+                name="high_p95_latency",
+                message=(
+                    f"Latence P95 {kpi.p95_e2e_ms:.0f}ms "
+                    f"> seuil {self.max_p95_latency_ms:.0f}ms"
+                ),
+                value=kpi.p95_e2e_ms,
+                threshold=self.max_p95_latency_ms,
+            ))
+
+        # Pannes Leon
+        if kpi.total_interactions > 0:
+            leon_rate = kpi.leon_failure_count / kpi.total_interactions
+            if leon_rate > self.max_leon_failure_rate:
+                alerts.append(Alert(
+                    level="critical",
+                    name="leon_unavailable",
+                    message=(
+                        f"Taux panne Leon {leon_rate:.1%} "
+                        f"> seuil {self.max_leon_failure_rate:.1%}"
+                    ),
+                    value=leon_rate,
+                    threshold=self.max_leon_failure_rate,
+                ))
+
+            # Pannes provider
+            provider_rate = kpi.provider_failure_count / kpi.total_interactions
+            if provider_rate > self.max_provider_failure_rate:
+                alerts.append(Alert(
+                    level="critical",
+                    name="provider_unavailable",
+                    message=(
+                        f"Taux panne provider {provider_rate:.1%} "
+                        f"> seuil {self.max_provider_failure_rate:.1%}"
+                    ),
+                    value=provider_rate,
+                    threshold=self.max_provider_failure_rate,
+                ))
+
+        return alerts
+
+    def is_healthy(self) -> bool:
+        return len(self.check_all()) == 0

--- a/tests/test_observability.py
+++ b/tests/test_observability.py
@@ -1,0 +1,312 @@
+"""Tests d'observabilité: KPI, tracing corrélé, alertes provider/Leon.
+
+Critères ticket #307:
+- KPI exposés pour au moins 3 parcours de démo (light, meteo, timer)
+- Corrélation traçable de bout en bout sur 10 interactions
+- Alertes testées sur panne provider et panne Leon
+"""
+from __future__ import annotations
+
+import unittest
+import uuid
+
+from src.assistant.observability import (
+    Alert,
+    AlertManager,
+    InteractionTrace,
+    KpiSummary,
+    MetricsCollector,
+)
+
+
+def _cid() -> str:
+    return str(uuid.uuid4())
+
+
+class TestMetricsCollector(unittest.TestCase):
+    def setUp(self) -> None:
+        self.collector = MetricsCollector()
+
+    # -- Enregistrement -------------------------------------------------------
+
+    def test_record_interaction_adds_trace(self) -> None:
+        cid = _cid()
+        trace = self.collector.record_interaction(
+            correlation_id=cid, intent="light", route="local",
+            stt_ms=120.0, orchestrator_ms=30.0, tts_ms=200.0, success=True,
+        )
+        self.assertEqual(len(self.collector.all_traces()), 1)
+        self.assertEqual(trace.correlation_id, cid)
+        self.assertAlmostEqual(trace.e2e_ms, 350.0)
+
+    def test_10_interactions_all_traceable_by_correlation_id(self) -> None:
+        """Corrélation traçable de bout en bout sur 10 interactions."""
+        cids = [_cid() for _ in range(10)]
+        for cid in cids:
+            self.collector.record_interaction(
+                correlation_id=cid, intent="light", route="local",
+                stt_ms=100.0, orchestrator_ms=20.0, tts_ms=180.0, success=True,
+            )
+        self.assertEqual(len(self.collector.unique_correlation_ids()), 10)
+        for cid in cids:
+            traces = self.collector.traces_for_correlation(cid)
+            self.assertEqual(len(traces), 1)
+            self.assertEqual(traces[0].correlation_id, cid)
+
+    def test_reset_clears_all_traces(self) -> None:
+        self.collector.record_interaction(
+            correlation_id=_cid(), intent="light", route="local", success=True
+        )
+        self.collector.reset()
+        self.assertEqual(len(self.collector.all_traces()), 0)
+
+    # -- KPI vides ------------------------------------------------------------
+
+    def test_kpi_summary_no_traces_returns_zero_defaults(self) -> None:
+        kpi = self.collector.kpi_summary()
+        self.assertEqual(kpi.total_interactions, 0)
+        self.assertEqual(kpi.success_rate, 0.0)
+
+    # -- KPI 3 parcours de démo -----------------------------------------------
+
+    def _populate_3_parcours(self) -> None:
+        """Peuple le collecteur avec 3 parcours: light, meteo, timer."""
+        for _ in range(4):
+            self.collector.record_interaction(
+                correlation_id=_cid(), intent="light", route="local",
+                stt_ms=120.0, orchestrator_ms=25.0, tts_ms=180.0, success=True,
+            )
+        for _ in range(3):
+            self.collector.record_interaction(
+                correlation_id=_cid(), intent="meteo", route="local",
+                stt_ms=140.0, orchestrator_ms=35.0, tts_ms=200.0, success=True,
+            )
+        for _ in range(3):
+            self.collector.record_interaction(
+                correlation_id=_cid(), intent="timer", route="local",
+                stt_ms=100.0, orchestrator_ms=20.0, tts_ms=160.0, success=True,
+            )
+
+    def test_kpi_covers_3_demo_parcours(self) -> None:
+        """KPI exposés pour au moins 3 parcours de démo."""
+        self._populate_3_parcours()
+        kpi = self.collector.kpi_summary()
+        self.assertEqual(kpi.total_interactions, 10)
+        self.assertEqual(kpi.success_count, 10)
+        self.assertAlmostEqual(kpi.success_rate, 1.0)
+        self.assertIn("light", kpi.intent_distribution)
+        self.assertIn("meteo", kpi.intent_distribution)
+        self.assertIn("timer", kpi.intent_distribution)
+        self.assertGreater(kpi.median_e2e_ms, 0)
+        self.assertGreater(kpi.p95_e2e_ms, 0)
+
+    def test_kpi_for_parcours_light(self) -> None:
+        self._populate_3_parcours()
+        kpi = self.collector.kpi_for_parcours("light")
+        self.assertEqual(kpi.total_interactions, 4)
+        self.assertAlmostEqual(kpi.success_rate, 1.0)
+
+    def test_kpi_for_parcours_meteo(self) -> None:
+        self._populate_3_parcours()
+        kpi = self.collector.kpi_for_parcours("meteo")
+        self.assertEqual(kpi.total_interactions, 3)
+
+    def test_kpi_for_parcours_timer(self) -> None:
+        self._populate_3_parcours()
+        kpi = self.collector.kpi_for_parcours("timer")
+        self.assertEqual(kpi.total_interactions, 3)
+
+    # -- KPI avec erreurs -----------------------------------------------------
+
+    def test_kpi_counts_failures_correctly(self) -> None:
+        for _ in range(8):
+            self.collector.record_interaction(
+                correlation_id=_cid(), intent="light", route="local", success=True
+            )
+        for _ in range(2):
+            self.collector.record_interaction(
+                correlation_id=_cid(), intent="light", route="error",
+                success=False, error_type="provider_failure",
+            )
+        kpi = self.collector.kpi_summary()
+        self.assertEqual(kpi.success_count, 8)
+        self.assertEqual(kpi.failure_count, 2)
+        self.assertAlmostEqual(kpi.success_rate, 0.8)
+        self.assertEqual(kpi.provider_failure_count, 2)
+
+    # -- Export Prometheus ----------------------------------------------------
+
+    def test_export_prometheus_text_contains_required_metrics(self) -> None:
+        self._populate_3_parcours()
+        text = self.collector.export_prometheus_text()
+        self.assertIn("interactions_total 10", text)
+        self.assertIn("interactions_success_total 10", text)
+        self.assertIn("interactions_failure_total 0", text)
+        self.assertIn("success_rate 1.0000", text)
+        self.assertIn("e2e_latency_ms_median", text)
+        self.assertIn("e2e_latency_ms_p95", text)
+        self.assertIn('routing_total{route="local"}', text)
+
+
+class TestAlertManager(unittest.TestCase):
+    def setUp(self) -> None:
+        self.collector = MetricsCollector()
+        self.alerts = AlertManager(
+            self.collector,
+            max_failure_rate=0.20,
+            max_p95_latency_ms=2500.0,
+            max_leon_failure_rate=0.10,
+            max_provider_failure_rate=0.10,
+            min_interactions_for_alert=3,
+        )
+
+    # -- Système sain --------------------------------------------------------
+
+    def test_no_alerts_when_all_ok(self) -> None:
+        for _ in range(10):
+            self.collector.record_interaction(
+                correlation_id=_cid(), intent="light", route="local",
+                stt_ms=100.0, orchestrator_ms=20.0, tts_ms=200.0, success=True,
+            )
+        self.assertEqual(self.alerts.check_all(), [])
+        self.assertTrue(self.alerts.is_healthy())
+
+    def test_no_alerts_below_min_interactions(self) -> None:
+        """Pas d'alerte si moins de min_interactions_for_alert traces."""
+        self.collector.record_interaction(
+            correlation_id=_cid(), intent="light", route="error",
+            success=False, error_type="provider_failure",
+        )
+        self.assertEqual(self.alerts.check_all(), [])
+
+    # -- Alerte panne provider -----------------------------------------------
+
+    def test_alert_raised_on_provider_failure(self) -> None:
+        """Alerte testée sur panne provider (critère #307)."""
+        for _ in range(7):
+            self.collector.record_interaction(
+                correlation_id=_cid(), intent="light", route="local", success=True
+            )
+        for _ in range(3):
+            self.collector.record_interaction(
+                correlation_id=_cid(), intent="light", route="error",
+                success=False, error_type="provider_failure",
+            )
+        active = self.alerts.check_all()
+        names = [a.name for a in active]
+        self.assertIn("provider_unavailable", names)
+        alert = next(a for a in active if a.name == "provider_unavailable")
+        self.assertEqual(alert.level, "critical")
+        self.assertGreater(alert.value, self.alerts.max_provider_failure_rate)
+
+    def test_no_provider_alert_below_threshold(self) -> None:
+        for _ in range(10):
+            self.collector.record_interaction(
+                correlation_id=_cid(), intent="light", route="local", success=True
+            )
+        self.collector.record_interaction(
+            correlation_id=_cid(), intent="light", route="error",
+            success=False, error_type="provider_failure",
+        )
+        names = [a.name for a in self.alerts.check_all()]
+        self.assertNotIn("provider_unavailable", names)
+
+    # -- Alerte panne Leon ---------------------------------------------------
+
+    def test_alert_raised_on_leon_failure(self) -> None:
+        """Alerte testée sur panne Leon (critère #307)."""
+        for _ in range(7):
+            self.collector.record_interaction(
+                correlation_id=_cid(), intent="light", route="local", success=True
+            )
+        for _ in range(3):
+            self.collector.record_interaction(
+                correlation_id=_cid(), intent="light", route="error",
+                success=False, error_type="leon_failure",
+            )
+        active = self.alerts.check_all()
+        names = [a.name for a in active]
+        self.assertIn("leon_unavailable", names)
+        alert = next(a for a in active if a.name == "leon_unavailable")
+        self.assertEqual(alert.level, "critical")
+
+    def test_no_leon_alert_below_threshold(self) -> None:
+        for _ in range(20):
+            self.collector.record_interaction(
+                correlation_id=_cid(), intent="light", route="local", success=True
+            )
+        self.collector.record_interaction(
+            correlation_id=_cid(), intent="light", route="error",
+            success=False, error_type="leon_failure",
+        )
+        names = [a.name for a in self.alerts.check_all()]
+        self.assertNotIn("leon_unavailable", names)
+
+    # -- Alerte taux d'échec global ------------------------------------------
+
+    def test_alert_on_high_failure_rate(self) -> None:
+        for _ in range(5):
+            self.collector.record_interaction(
+                correlation_id=_cid(), intent="light", route="local", success=True
+            )
+        for _ in range(5):
+            self.collector.record_interaction(
+                correlation_id=_cid(), intent="light", route="error",
+                success=False, error_type="timeout",
+            )
+        names = [a.name for a in self.alerts.check_all()]
+        self.assertIn("high_failure_rate", names)
+
+    # -- Alerte latence P95 --------------------------------------------------
+
+    def test_alert_on_high_p95_latency(self) -> None:
+        # 2 rapides (320ms) + 2 lentes (2700ms) → P95 = index 2 = 2700ms
+        for _ in range(2):
+            self.collector.record_interaction(
+                correlation_id=_cid(), intent="light", route="local",
+                stt_ms=100.0, orchestrator_ms=20.0, tts_ms=200.0, success=True,
+            )
+        for _ in range(2):
+            self.collector.record_interaction(
+                correlation_id=_cid(), intent="light", route="local",
+                stt_ms=1000.0, orchestrator_ms=500.0, tts_ms=1200.0, success=True,
+            )
+        names = [a.name for a in self.alerts.check_all()]
+        self.assertIn("high_p95_latency", names)
+
+    def test_no_latency_alert_within_threshold(self) -> None:
+        for _ in range(10):
+            self.collector.record_interaction(
+                correlation_id=_cid(), intent="light", route="local",
+                stt_ms=100.0, orchestrator_ms=20.0, tts_ms=200.0, success=True,
+            )
+        names = [a.name for a in self.alerts.check_all()]
+        self.assertNotIn("high_p95_latency", names)
+
+    # -- Cumul d'alertes -----------------------------------------------------
+
+    def test_multiple_alerts_can_fire_simultaneously(self) -> None:
+        """Leon + provider en panne simultanément."""
+        for _ in range(4):
+            self.collector.record_interaction(
+                correlation_id=_cid(), intent="light", route="local", success=True
+            )
+        for _ in range(2):
+            self.collector.record_interaction(
+                correlation_id=_cid(), intent="light", route="error",
+                success=False, error_type="leon_failure",
+            )
+        for _ in range(2):
+            self.collector.record_interaction(
+                correlation_id=_cid(), intent="light", route="error",
+                success=False, error_type="provider_failure",
+            )
+        active = self.alerts.check_all()
+        names = [a.name for a in active]
+        self.assertIn("leon_unavailable", names)
+        self.assertIn("provider_unavailable", names)
+        self.assertFalse(self.alerts.is_healthy())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Closes #307

### Ce qui a été fait
- Nouveau module `src/assistant/observability.py` (zéro dépendance externe):
  - `MetricsCollector`: enregistrement de traces `InteractionTrace` avec correlation_id, latences STT/orchestrator/TTS/provider, succès/erreur
  - `KpiSummary`: total, taux succès, médiane E2E, P95, distribution intents/routes/erreurs
  - Export Prometheus-like (`export_prometheus_text()`)
  - `AlertManager`: alertes sur taux échec global, latence P95, panne Leon, panne provider

### Critères d'acceptance validés
- ✅ KPI pour 3 parcours de démo: light, meteo, timer (`kpi_for_parcours()`)
- ✅ Corrélation traçable sur 10 interactions: 10 UUID uniques, retrouvables par `traces_for_correlation()`
- ✅ Alerte testée sur panne provider (`provider_unavailable`, level=critical)
- ✅ Alerte testée sur panne Leon (`leon_unavailable`, level=critical)

### Tests
```
20 passed (test_observability.py)
458 passed total
```